### PR TITLE
complete sb/society manage views

### DIFF
--- a/account/tests.py
+++ b/account/tests.py
@@ -81,7 +81,7 @@ class AccountTests(TestCase):
         student_user = self.createUser('smsnb')
         self.createStudent(student_user)
         society_user = self.createUser('tjwnb')
-        self.createSociety(society_user, 101, None)
+        self.createSociety(user=society_user, society_id=101, members=None)
         sb_user = self.createUser('ncjnb')
         self.createSocietyBureau(sb_user)
 

--- a/society/models.py
+++ b/society/models.py
@@ -52,6 +52,22 @@ class Society(models.Model):
     def __str__(self):
         return str(self.society_id) + ' ' + self.name
 
+    def auto_generate_id(self):
+        society_id = self.type * 100 + 1
+        societies = Society.objects.filter(type=self.type,
+                                           status__in=[SocietyStatus.ACTIVE, SocietyStatus.ARCHIVED]).order_by(
+            'society_id')
+        for society in societies:
+            if society.society_id != society_id:
+                return society_id
+            society_id += 1
+        return society_id
+
+    def check_id(self, society_id):
+        if society_id <= self.type * 100 or society_id >= (self.type + 1) * 100:
+            return False
+        return True
+
 
 class JoinSocietyRequest(models.Model):
     society = models.ForeignKey(Society, on_delete=models.DO_NOTHING)

--- a/society_bureau/api/serializers.py
+++ b/society_bureau/api/serializers.py
@@ -27,6 +27,12 @@ class SocietyMiniSerializer(serializers.ModelSerializer):
         )
 
 
+class ConfirmSocietySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Society
+        fields = ('id', 'society_id')
+
+
 class SettingsSerializer(serializers.ModelSerializer):
     class Meta:
         model = SiteSettings

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -2,8 +2,8 @@ from rest_framework.test import APIClient
 from testing.testcases import TestCase
 
 from society.constants import SocietyType, SocietyStatus
-from society.models import ActivityRequest
 from society_manage.models import CreditReceivers
+from society.models import Society
 
 
 class DashboardTests(TestCase):
@@ -98,8 +98,13 @@ class SocietyManageTests(TestCase):
 
         client.force_authenticate(self.user4)
         response = client.delete(url, decode=True)
+        self.assertEqual(response.status_code, 403)
+
+        self.society1.status = SocietyStatus.ARCHIVED
+        self.society1.save()
+        response = client.delete(url, decode=True)
         self.assertEqual(response.status_code, 204)
-        self.assertIsNone(ActivityRequest.objects.filter(pk=self.society1.pk).first())
+        self.assertIsNone(Society.objects.filter(pk=self.society1.pk).first())
 
 
 class CreditManageTests(TestCase):

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -81,7 +81,7 @@ class SocietyManageViewSet(
             return Response(status=status.HTTP_202_ACCEPTED)
         return Response(
             status=status.HTTP_400_BAD_REQUEST,
-            data={'detail': '表单填写错误'}
+            data={'detail': '社团ID重复'}
         )
 
     @action(detail=True, methods=['post'])

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -34,8 +34,8 @@ class TestCase(DjangoTestCase):
     def createSociety(
             self,
             user,
-            society_id,
             members,
+            society_id=None,
             status=SocietyStatus.WAITING,
             society_type=SocietyType.HUMANISTIC,
             name='jeek1',

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -1,7 +1,7 @@
 from rest_framework import permissions
 
-from society.models import JoinSocietyRequest, ActivityRequest
-from society.constants import JoinSocietyRequestStatus, ActivityRequestStatus
+from society.models import JoinSocietyRequest
+from society.constants import JoinSocietyRequestStatus, ActivityRequestStatus, SocietyStatus
 
 
 class IsStudent(permissions.BasePermission):
@@ -72,3 +72,24 @@ class SocietyActivityEditable(permissions.BasePermission):
         if request.method != 'PATCH' and request.method != 'PUT':
             return True
         return obj.status == ActivityRequestStatus.WAITING
+
+
+class SocietyIsWaiting(permissions.BasePermission):
+    message = 'Only Waiting Society Allowed'
+
+    def has_object_permission(self, request, view, obj):
+        return obj.status == SocietyStatus.WAITING
+
+
+class SocietyIsActive(permissions.BasePermission):
+    message = 'Only Active Society Allowed'
+
+    def has_object_permission(self, request, view, obj):
+        return obj.status == SocietyStatus.ACTIVE
+
+
+class SocietyIsArchived(permissions.BasePermission):
+    message = 'Only Archived Society Allowed'
+
+    def has_object_permission(self, request, view, obj):
+        return obj.status == SocietyStatus.ARCHIVED


### PR DESCRIPTION
* confirm: 通过社团建立的申请，前端可以手动分配社团ID，后端有check，如果前端form留空，后端会自动生成ID
* archive: 归档active的社团，用户设为inactive。
* 修改了一些queryset和test