### PR TITLE
manage credit

### DIFF
--- a/react/src/app/society_bureau/credit/components/CreditDistributionList.js
+++ b/react/src/app/society_bureau/credit/components/CreditDistributionList.js
@@ -10,7 +10,7 @@ import '../styles/credit.scss'
 @observer
 class CreditDistributionList extends React.Component {
     componentDidMount() {
-        CreditStore.fetch(1, 10)
+        CreditStore.fetch({})
     }
 
     state = {

--- a/react/src/app/society_bureau/credit/components/CreditDistributionList.js
+++ b/react/src/app/society_bureau/credit/components/CreditDistributionList.js
@@ -1,30 +1,39 @@
 import React from 'react';
-import {Form, Table, Button, InputNumber, Icon, Tooltip, Modal} from 'antd';
+import {Form, Table, Button, InputNumber, Icon, Tooltip, Modal, notification} from 'antd';
 
 import Provider from "../../../../utils/provider";
 import '../styles/credit.scss'
 
 
 class CreditDistributionList extends React.Component {
+    componentDidMount() {
+        this.fetch(1, 10)
+    }
+
+    fetch = (pageNum, pageSize) => {
+        Provider.get('/api/manage/credit/', {
+            params: {
+                page: pageNum,
+                page_size: pageSize
+            }
+        })
+            .then((res) => {
+                this.setState({ data: res.data.results, count: res.data.count })
+            })
+            .catch((e) => {
+                throw e;
+            })
+    };
+
     state = {
         setCreditModalVisible: false,
-        setCredit: 0,
+        setCredit: 1,
+        count: 0,
         editing: {
             id: 0,
             index: 0
         },
-        data: [
-            {
-                id: 1,
-                society: {
-                    society_id: 101,
-                    name: 'jeek'
-                },
-                credit: 0,
-                receivers_count: 0,
-                receivers: []
-            }
-        ]
+        data: []
     };
 
     renderCheckReceiversDetail = () => {
@@ -36,24 +45,34 @@ class CreditDistributionList extends React.Component {
     };
 
     showSetCreditModal = (id, index) => {
-        this.setState({setCreditModalVisible: true, editing: {id: id, index: index}});
+        this.setState({ setCreditModalVisible: true, editing: { id: id, index: index } });
     };
 
     handleSetCreditChange = (value) => {
-        this.setState({setCredit: value})
+        this.setState({ setCredit: value })
     };
 
     updateCredit = () => {
-        Provider.patch(`/api/manage/credit/${this.state.editing.id}/`,)
+        Provider.patch(
+            `/api/manage/credit/${this.state.editing.id}/`,
+            { credit: this.state.setCredit }
+        )
             .then((res) => {
                 let data = this.state.data;
-                data[this.state.editing.index].credit = credit;
-                this.setState({data: data});
-                console.log(res)
+                data[this.state.editing.index].credit = this.state.setCredit;
+                this.setState({
+                    setCreditModalVisible: false,
+                    setCredit: 1,
+                    data: data
+                });
             })
             .catch((err) => {
-                console.log(err)
+                throw err
             })
+    };
+
+    onPaginationChange = (pagination) => {
+        this.fetch(pagination.current, pagination.pageSize);
     };
 
     render() {
@@ -77,7 +96,8 @@ class CreditDistributionList extends React.Component {
                         <div>
                             {credit}
                             <Tooltip title="点击编辑按钮修改该社团分配学分人数上限">
-                                <Icon type="edit" className="edit-icon" onClick={() => this.showSetCreditModal(record.id, index)}/>
+                                <Icon type="edit" className="edit-icon"
+                                      onClick={() => this.showSetCreditModal(record.id, index)}/>
                             </Tooltip>
                         </div>
                     )
@@ -99,6 +119,11 @@ class CreditDistributionList extends React.Component {
             <div>
                 <Table
                     className="mt-2"
+                    pagination={{
+                        showSizeChanger: true,
+                        total: this.state.count
+                    }}
+                    onChange={this.onPaginationChange}
                     columns={columns}
                     dataSource={this.state.data}
                     rowKey="id"
@@ -106,11 +131,12 @@ class CreditDistributionList extends React.Component {
                 <Modal visible={this.state.setCreditModalVisible}
                        okText="更新！"
                        cancelText="算了吧"
-                       onCancel={() => this.setState({setCreditModalVisible: false})}
+                       onCancel={() => this.setState({ setCreditModalVisible: false })}
                        onOk={() => this.updateCredit()}>
                     <Form>
                         <Form.Item label="分配学分人数上限">
                             <InputNumber
+                                min={1}
                                 value={this.state.setCredit}
                                 onChange={(value) => this.handleSetCreditChange(value)}
                             />

--- a/react/src/app/society_bureau/credit/components/CreditDistributionList.js
+++ b/react/src/app/society_bureau/credit/components/CreditDistributionList.js
@@ -1,39 +1,25 @@
 import React from 'react';
 import {Form, Table, Button, InputNumber, Icon, Tooltip, Modal, notification} from 'antd';
+import {observer} from 'mobx-react'
 
+import CreditStore from '../stores/CreditStore'
 import Provider from "../../../../utils/provider";
 import '../styles/credit.scss'
 
 
+@observer
 class CreditDistributionList extends React.Component {
     componentDidMount() {
-        this.fetch(1, 10)
+        CreditStore.fetch(1, 10)
     }
-
-    fetch = (pageNum, pageSize) => {
-        Provider.get('/api/manage/credit/', {
-            params: {
-                page: pageNum,
-                page_size: pageSize
-            }
-        })
-            .then((res) => {
-                this.setState({ data: res.data.results, count: res.data.count })
-            })
-            .catch((e) => {
-                throw e;
-            })
-    };
 
     state = {
         setCreditModalVisible: false,
         setCredit: 1,
-        count: 0,
         editing: {
             id: 0,
             index: 0
-        },
-        data: []
+        }
     };
 
     renderCheckReceiversDetail = () => {
@@ -72,7 +58,7 @@ class CreditDistributionList extends React.Component {
     };
 
     onPaginationChange = (pagination) => {
-        this.fetch(pagination.current, pagination.pageSize);
+        CreditStore.fetch(pagination.current, pagination.pageSize);
     };
 
     render() {
@@ -125,7 +111,7 @@ class CreditDistributionList extends React.Component {
                     }}
                     onChange={this.onPaginationChange}
                     columns={columns}
-                    dataSource={this.state.data}
+                    dataSource={CreditStore.data}
                     rowKey="id"
                 />
                 <Modal visible={this.state.setCreditModalVisible}

--- a/react/src/app/society_bureau/credit/containers/CreditContainer.js
+++ b/react/src/app/society_bureau/credit/containers/CreditContainer.js
@@ -4,6 +4,8 @@ import CreditDistributionList from "../components/CreditDistributionList";
 import CreditSetAllModal from '../components/CreditSetAllModal'
 import YearSemesterSelect from '../../../../shared/YearSemesterSelect/YearSemesterSelect'
 
+import Provider from '../../../../utils/provider'
+
 class CreditContainer extends React.Component {
     state = {
         setAllModalVisible: false,
@@ -13,7 +15,7 @@ class CreditContainer extends React.Component {
     };
 
     submitSetAllCredit = () => {
-
+        Provider.post()
     };
 
     render() {

--- a/react/src/app/society_bureau/credit/containers/CreditContainer.js
+++ b/react/src/app/society_bureau/credit/containers/CreditContainer.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import {Button} from 'antd';
+import {observer} from 'mobx-react'
 import CreditDistributionList from "../components/CreditDistributionList";
 import CreditSetAllModal from '../components/CreditSetAllModal'
 import YearSemesterSelect from '../../../../shared/YearSemesterSelect/YearSemesterSelect'
+import CreditStore from '../stores/CreditStore'
 
 import Provider from '../../../../utils/provider'
 
+@observer
 class CreditContainer extends React.Component {
     state = {
         setAllModalVisible: false,
@@ -18,12 +21,24 @@ class CreditContainer extends React.Component {
         Provider.post()
     };
 
+    handleSearchButtonOnClick = () => {
+        CreditStore.fetch({
+            pageNum: CreditStore.pageNum,
+            pageSize: CreditStore.pageSize,
+            year: CreditStore.year,
+            semester:CreditStore.semester
+        })
+    };
+
     render() {
         return (
             <>
                 <YearSemesterSelect
-                    year={this.state.year}
-                    semester={this.state.semester}
+                    year={CreditStore.year}
+                    semester={CreditStore.semester}
+                    yearOnChange={(value) => {CreditStore.year = value}}
+                    semesterOnChange={(value) => {CreditStore.semester = value}}
+                    searchButtonOnClick={this.handleSearchButtonOnClick}
                 />
                 <Button onClick={() => this.setState({setAllModalVisible: true})}>
                     一键全部设置获得学分人数

--- a/react/src/app/society_bureau/credit/containers/CreditContainer.js
+++ b/react/src/app/society_bureau/credit/containers/CreditContainer.js
@@ -31,8 +31,8 @@ class CreditContainer extends React.Component {
                     this.state.setAllModalVisible &&
                     <CreditSetAllModal
                         credit={this.state.setAllCredit}
-                        onChange={(value) => this.setState({setAllCredit: value})}
-                        onCancel={() => this.setState({setAllModalVisible: false})}
+                        onChange={(value) => this.setState({ setAllCredit: value })}
+                        onCancel={() => this.setState({ setAllModalVisible: false })}
                         onOk={() => this.submitSetAllCredit()}
                     />
                 }

--- a/react/src/app/society_bureau/credit/stores/CreditStore.js
+++ b/react/src/app/society_bureau/credit/stores/CreditStore.js
@@ -1,7 +1,12 @@
+import {observable} from "mobx";
 import ListStore from '../../../../shared/stores/ListStore';
 
 class CreditStore extends ListStore {
-    url = '/api/manage/credit/'
+    url = '/api/manage/credit/';
+
+    @observable year = null;
+    @observable semester = null;
+
 }
 
 export default new CreditStore;

--- a/react/src/app/society_bureau/credit/stores/CreditStore.js
+++ b/react/src/app/society_bureau/credit/stores/CreditStore.js
@@ -1,0 +1,7 @@
+import ListStore from '../../../../shared/stores/ListStore';
+
+class CreditStore extends ListStore {
+    url = '/api/manage/credit/'
+}
+
+export default new CreditStore;

--- a/react/src/shared/YearSemesterSelect/YearSemesterSelect.js
+++ b/react/src/shared/YearSemesterSelect/YearSemesterSelect.js
@@ -34,6 +34,7 @@ class YearSemesterSelect extends React.Component {
                 <Select
                     value={this.props.year}
                     className="year-select"
+                    onChange={this.props.yearOnChange}
                 >
                     {
                         this.state.yearOptions.map((option) => (
@@ -44,12 +45,13 @@ class YearSemesterSelect extends React.Component {
                 <Select
                     className="semester-select"
                     value={this.props.semester}
+                    onChange={this.props.semesterOnChange}
                 >
                     <Option value="1" key="1">第一学期</Option>
                     <Option value="2" key="2">第二学期</Option>
                 </Select>
                 <Button
-                    onClick={() => this.props.searchButtonOnClick}
+                    onClick={this.props.searchButtonOnClick}
                     htmlType="button"
                     className="search-button"
                     type="primary"
@@ -64,8 +66,6 @@ class YearSemesterSelect extends React.Component {
 YearSemesterSelect.propTypes = {
     yearOnChange: PropTypes.func,
     semesterOnChange: PropTypes.func,
-    semester: PropTypes.number.isRequired,
-    year: PropTypes.number.isRequired,
     searchButtonOnClick: PropTypes.func.isRequired
 };
 

--- a/react/src/shared/stores/ListStore.js
+++ b/react/src/shared/stores/ListStore.js
@@ -1,0 +1,49 @@
+import {observable, action} from 'mobx';
+import {notification} from "antd";
+
+import Provider from '../../utils/provider';
+
+class ListStore {
+    @observable loading = true;
+
+    @observable data = [];
+
+    @observable count = 0;
+    @observable pageSize = 10;
+    @observable pageNum = 0;
+
+    url = '';
+
+    @action fetch = (pageNum, pageSize, ...rest) => {
+        this.loading = true;
+        return Provider.get(this.url, {
+            params: {
+                page: pageNum,
+                page_size: pageSize,
+                ...rest
+            }
+        })
+            .then((res) => {
+                this.data = res.data.results;
+                this.count = res.data.count;
+                this.loading = false
+            })
+            .catch((err) => {
+                notification.error({
+                    message: '失败',
+                    description: '获取列表失败'
+                });
+                throw err;
+            })
+    };
+
+    @action update = () => {
+
+    };
+
+    @action delete = () => {
+
+    };
+}
+
+export default ListStore;

--- a/react/src/shared/stores/ListStore.js
+++ b/react/src/shared/stores/ListStore.js
@@ -10,17 +10,17 @@ class ListStore {
 
     @observable count = 0;
     @observable pageSize = 10;
-    @observable pageNum = 0;
+    @observable pageNum = 1;
 
     url = '';
 
-    @action fetch = (pageNum, pageSize, ...rest) => {
+    @action fetch = ({ pageNum = 1, pageSize = 10, ...params }) => {
         this.loading = true;
         return Provider.get(this.url, {
             params: {
                 page: pageNum,
                 page_size: pageSize,
-                ...rest
+                ...params
             }
         })
             .then((res) => {

--- a/society_bureau/api/serializers.py
+++ b/society_bureau/api/serializers.py
@@ -126,6 +126,10 @@ class CreditDistributionManualCreateSerializer(serializers.Serializer):
         )
 
 
+class CreditDistributionBulkCreateSerializer(serializers.Serializer):
+    year = serializers.IntegerField()
+    semester = serializers.IntegerField()
+
 class SiteSettingsRetrieveSerializer(serializers.Serializer):
     year = serializers.SerializerMethodField()
     semester = serializers.SerializerMethodField()

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -242,7 +242,10 @@ class CreditReceiversTests(TestCase):
         self.student = self.createStudent(user=self.user4)
 
     def test_list_credit_distributions(self):
-        url = '/api/manage/credit/'
+        url = '/api/manage/credit/?year={year}&semester={semester}'.format(
+            year=SettingsService.get('year'),
+            semester=SettingsService.get('semester')
+        )
 
         # test permissions
         client = APIClient(enforce_csrf_checks=True)
@@ -257,6 +260,7 @@ class CreditReceiversTests(TestCase):
         self.assertEqual(len(response.data['results']), 2)
         self.assertEqual(response.data['results'][0]['receivers_count'], 0)
         self.assertEqual(response.data['results'][0]['credit'], 1)
+        self.assertEqual(CreditDistribution.objects.count(), 2)
 
         # now there are credit distributions
         # so response the existing data
@@ -270,6 +274,13 @@ class CreditReceiversTests(TestCase):
         response = client.get(url, decode=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
+
+        url = '/api/manage/credit/?year={year}&semester={semester}'.format(
+            year=2017,
+            semester=2
+        )
+        client.get(url)
+        self.assertEqual(CreditDistribution.objects.count(), 4)
 
     def test_retrieve_credit_distribution(self):
         credit_distribution = CreditDistribution.objects.create(

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -231,6 +231,8 @@ class CreditReceiversTests(TestCase):
             members=None,
             society_type=SocietyType.HUMANISTIC
         )
+        self.society1.status = SocietyStatus.ACTIVE
+        self.society1.save()
         self.society2 = self.createSociety(
             user=self.user2,
             society_id=301,
@@ -238,6 +240,8 @@ class CreditReceiversTests(TestCase):
             members=None,
             society_type=SocietyType.SCIENTIFIC
         )
+        self.society2.status = SocietyStatus.ACTIVE
+        self.society2.save()
         self.society_bureau = self.createSocietyBureau(user=self.user3, real_name='xxx')
         self.student = self.createStudent(user=self.user4)
 

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -342,6 +342,13 @@ class CreditReceiversTests(TestCase):
         res = client.post(url, data=data, decode=True)
         self.assertEqual(res.status_code, 201)
 
+        CreditDistribution.objects.first().delete()
+
+        res = client.post(url, data=data, decode=True)
+        self.assertEqual(res.status_code, 201)
+
+        self.assertEqual(CreditDistribution.objects.count(), 2)
+
         data = {
             'yea': 1110,
             'semester': 2

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -254,14 +254,14 @@ class CreditReceiversTests(TestCase):
         client.force_authenticate(self.user3)
         response = client.get(url, decode=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]['receivers_count'], 0)
-        self.assertEqual(response.data[0]['credit'], 1)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['results'][0]['receivers_count'], 0)
+        self.assertEqual(response.data['results'][0]['credit'], 1)
 
         # now there are credit distributions
         # so response the existing data
         response = client.get(url, decode=True)
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data['results']), 2)
 
         # the following code is just a test
         # we should try our best to avoid this situation
@@ -269,7 +269,7 @@ class CreditReceiversTests(TestCase):
         # response the existing credit distribution
         response = client.get(url, decode=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_retrieve_credit_distribution(self):
         credit_distribution = CreditDistribution.objects.create(

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -280,7 +280,7 @@ class CreditReceiversTests(TestCase):
             semester=2
         )
         client.get(url)
-        self.assertEqual(CreditDistribution.objects.count(), 4)
+        self.assertEqual(CreditDistribution.objects.count(), 3)
 
     def test_retrieve_credit_distribution(self):
         credit_distribution = CreditDistribution.objects.create(

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -276,18 +276,31 @@ class CreditReceiversTests(TestCase):
         self.assertEqual(len(response.data['results']), 1)
 
         url = '/api/manage/credit/?year={year}&semester={semester}'.format(
-            year=2017,
+            year=SettingsService.get('year') - 1,
             semester=2
         )
         client.get(url)
-        self.assertEqual(CreditDistribution.objects.count(), 1)
+        self.assertEqual(CreditDistribution.objects.filter(
+            year=SettingsService.get('year') - 1,
+            semester=2
+        ).count(), 2)
+
+        url = '/api/manage/credit/?year={year}&semester={semester}'.format(
+            year=SettingsService.get('year'),
+            semester=SettingsService.get('semester') + 1
+        )
+        res = client.get(url)
+        self.assertEqual(res.status_code, 404)
 
         url = '/api/manage/credit/?year={year}&semester={semester}'.format(
             year=SettingsService.get('year') + 1110,
             semester=2
         )
         client.get(url)
-        self.assertEqual(CreditDistribution.objects.count(), 0)
+        self.assertEqual(CreditDistribution.objects.filter(
+            year=SettingsService.get('year') + 1110,
+            semester=2
+        ).count(), 0)
 
     def test_retrieve_credit_distribution(self):
         credit_distribution = CreditDistribution.objects.create(

--- a/society_bureau/api/tests.py
+++ b/society_bureau/api/tests.py
@@ -280,7 +280,14 @@ class CreditReceiversTests(TestCase):
             semester=2
         )
         client.get(url)
-        self.assertEqual(CreditDistribution.objects.count(), 3)
+        self.assertEqual(CreditDistribution.objects.count(), 1)
+
+        url = '/api/manage/credit/?year={year}&semester={semester}'.format(
+            year=SettingsService.get('year') + 1110,
+            semester=2
+        )
+        client.get(url)
+        self.assertEqual(CreditDistribution.objects.count(), 0)
 
     def test_retrieve_credit_distribution(self):
         credit_distribution = CreditDistribution.objects.create(

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -149,22 +149,20 @@ class CreditManageViewSet(
         return CreditDistribution.objects.all().order_by('-year', '-semester', 'society__society_id')
 
     def list(self, request, *args, **kwargs):
-        if self.get_queryset().exists():
-            queryset = self.filter_queryset(self.get_queryset())
-
+        queryset = self.filter_queryset(self.get_queryset())
+        if queryset.exists():
             page = self.paginate_queryset(queryset)
             if page is not None:
                 serializer = self.get_serializer(page, many=True)
                 return self.get_paginated_response(serializer.data)
-
             serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
         credit_distribution_sets = []
         for society in Society.objects.filter(status=SocietyStatus.WAITING):
             queryset = CreditDistribution.objects.create(
                 society=society,
-                semester=SettingsService.get('semester'),
-                year=SettingsService.get('year')
+                semester=request.query_params['semester'],
+                year=request.query_params['year']
             )
             credit_distribution_sets.append(queryset)
         page = self.paginate_queryset(credit_distribution_sets)

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -154,18 +154,16 @@ class CreditManageViewSet(
         serializer = CreditDistributionBulkCreateSerializer(data=request.data)
         if serializer.is_valid():
             for society in Society.objects.filter(status=SocietyStatus.ACTIVE):
-                if CreditDistribution.objects.filter(
+                if not CreditDistribution.objects.filter(
                     semester=request.data['semester'],
                     year=request.data['year'],
                     society=society
                 ).exists():
-                    pass
-                else:
                     CreditDistribution.objects.create(
                         society=society,
                         semester=request.data['semester'],
                         year=request.data['year']
-                    )
+                    )           
             return Response(status=status.HTTP_201_CREATED)
         return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -151,8 +151,9 @@ class CreditManageViewSet(
     def list(self, request, *args, **kwargs):
         year = request.query_params.get('year', None)
         semester = request.query_params.get('semester', None)
-        if (year and int(year) > SettingsService.get('year')) or (
-                semester and int(semester) > SettingsService.get('semester')):
+        if year and int(year) > SettingsService.get('year'):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        if year and int(year) == SettingsService.get('year') and (semester and int(semester) > SettingsService.get('semester')):
             return Response(status=status.HTTP_404_NOT_FOUND)
         queryset = self.filter_queryset(self.get_queryset())
         if queryset.exists():

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -150,7 +150,14 @@ class CreditManageViewSet(
 
     def list(self, request, *args, **kwargs):
         if self.get_queryset().exists():
-            serializer = self.get_serializer(self.get_queryset(), many=True)
+            queryset = self.filter_queryset(self.get_queryset())
+
+            page = self.paginate_queryset(queryset)
+            if page is not None:
+                serializer = self.get_serializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+
+            serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
         credit_distribution_sets = []
         for society in Society.objects.filter(status=SocietyStatus.WAITING):
@@ -160,8 +167,10 @@ class CreditManageViewSet(
                 year=SettingsService.get('year')
             )
             credit_distribution_sets.append(queryset)
-        serializer = self.get_serializer(credit_distribution_sets, many=True)
-        return Response(serializer.data)
+        page = self.paginate_queryset(credit_distribution_sets)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
 
 
 class SettingsViewSet(

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -153,12 +153,19 @@ class CreditManageViewSet(
     def bulk_create(self, request):
         serializer = CreditDistributionBulkCreateSerializer(data=request.data)
         if serializer.is_valid():
-            for society in Society.objects.filter(status=SocietyStatus.WAITING):
-                CreditDistribution.objects.create(
-                    society=society,
+            for society in Society.objects.filter(status=SocietyStatus.ACTIVE):
+                if CreditDistribution.objects.filter(
                     semester=request.data['semester'],
-                    year=request.data['year']
-                )
+                    year=request.data['year'],
+                    society=society
+                ).exists():
+                    pass
+                else:
+                    CreditDistribution.objects.create(
+                        society=society,
+                        semester=request.data['semester'],
+                        year=request.data['year']
+                    )
             return Response(status=status.HTTP_201_CREATED)
         return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/society_bureau/api/views.py
+++ b/society_bureau/api/views.py
@@ -149,6 +149,11 @@ class CreditManageViewSet(
         return CreditDistribution.objects.all().order_by('-year', '-semester', 'society__society_id')
 
     def list(self, request, *args, **kwargs):
+        year = request.query_params.get('year', None)
+        semester = request.query_params.get('semester', None)
+        if (year and int(year) > SettingsService.get('year')) or (
+                semester and int(semester) > SettingsService.get('semester')):
+            return Response(status=status.HTTP_404_NOT_FOUND)
         queryset = self.filter_queryset(self.get_queryset())
         if queryset.exists():
             page = self.paginate_queryset(queryset)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6259386/53695268-272bb080-3df4-11e9-8ea1-970618a49b4e.png)
为manage的CreditContainer加入了学年和学期的选择
简单抽象出一个ListStore
下一个pr会卸掉ListStore的delete和update函数
以及抽象出ListStore的CheckDetail（用于查看data里的单独一个信息，只能查看,read_onl)y