### PR TITLE
Cn/notifications

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'notifications',
     'rest_framework',
     'graphene_django',
     'student.apps.StudentConfig',

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from config.views import react
 from config.router import router
 from config import settings
 from graphene_django.views import GraphQLView
+import notifications.urls
 
 urlpatterns = [
     path('', react),
@@ -15,4 +16,5 @@ urlpatterns = [
     re_path(r'^media/(?P<path>.*)$', serve, {
         'document_root': settings.MEDIA_ROOT,
     }),
+    path('notifications/', include(notifications.urls, namespace='notifications')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ openpyxl==2.6.1
 Rx==1.6.1
 singledispatch==3.4.0.3
 six==1.12.0
+django-notifications-hq==1.5.0

--- a/society/api/views.py
+++ b/society/api/views.py
@@ -21,6 +21,8 @@ from utils.filters import (
 )
 from society.constants import SocietyStatus
 from society_bureau.api.services import SettingsService
+import society.notifiers
+
 
 
 class SocietyViewSet(viewsets.GenericViewSet, RetrieveAPIView, ListAPIView):

--- a/society/notifiers.py
+++ b/society/notifiers.py
@@ -1,0 +1,24 @@
+from django.db.models.signals import post_save
+from notifications.signals import notify
+from society.models import JoinSocietyRequest
+from society.constants import JoinSocietyRequestStatus
+
+
+def my_handler(sender, instance, created, **kwargs):
+    if instance.status == JoinSocietyRequestStatus.ACCEPTED:
+        notify.send(
+            sender=instance.society,
+            recipient=instance.member.user,
+            verb='通过了你的入社申请',
+            public=False
+        )
+    if instance.status == JoinSocietyRequestStatus.DENIED:
+        notify.send(
+            sender=instance.society,
+            recipient=instance.member.user,
+            verb='拒绝了你的入社申请',
+            public=False
+        )
+
+
+post_save.connect(my_handler, sender=JoinSocietyRequest)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17191827/57930740-54630780-78e9-11e9-9c71-5ac83235ed30.png)
#124 
如图，内置了这些api，日常就够用了。

发送通知的逻辑：每个app内新建个notifiers.py，存放signal的回调函数，并与signal注册，在views内引入（一次）。
注意不能在app config内引入，因为要等models准备好才能注册signal。

单独建个文件的目的是降低代码耦合度，notifications也可以在views中直接用单个语句发送。

现在这个写法的缺陷是：无法在通知中增加models以外的信息。如，社团部拒绝社团创建后，需要填写拒绝理由（并非society的字段），就无法通过handler传递过去。
这个功能可以通过直接调用notify.send解决（把拒绝理由存在description里），后期考虑抽出部分到views中。